### PR TITLE
Added VNF resource consumption functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ install:
 script:
     - flake8 src
     - nose2
-    - coord-sim -d 20 -n params/networks/triangle.graphml -sf params/services/abc.yaml -c params/config/sim_config.yaml
+    - coord-sim -d 20 -n params/networks/triangle.graphml -sf params/services/abc.yaml -sfr params/services/resource_functions -c params/config/sim_config.yaml

--- a/params/services/abc.yaml
+++ b/params/services/abc.yaml
@@ -12,9 +12,11 @@ sf_list:
   a:
     processing_delay_mean: 5.0
     processing_delay_stdev: 0.0
+    resource_function_id: A
   b:
     processing_delay_mean: 5.0
     processing_delay_stdev: 0.0
+    resource_function_id: B
   c:
     processing_delay_mean: 5.0
     processing_delay_stdev: 0.0

--- a/params/services/resource_functions/A.py
+++ b/params/services/resource_functions/A.py
@@ -1,0 +1,2 @@
+def resource_function(load):
+	return load

--- a/params/services/resource_functions/A.py
+++ b/params/services/resource_functions/A.py
@@ -1,2 +1,2 @@
 def resource_function(load):
-	return load
+    return load

--- a/params/services/resource_functions/B.py
+++ b/params/services/resource_functions/B.py
@@ -1,0 +1,2 @@
+def resource_function(load):
+	return load

--- a/params/services/resource_functions/B.py
+++ b/params/services/resource_functions/B.py
@@ -1,2 +1,2 @@
 def resource_function(load):
-	return load
+    return load

--- a/src/coordsim/main.py
+++ b/src/coordsim/main.py
@@ -32,7 +32,7 @@ def main():
 
     # Getting current SFC list, and the SF list of each SFC, and config
     sfc_list = reader.get_sfc(args.sf)
-    sf_list = reader.get_sf(args.sf)
+    sf_list = reader.get_sf(args.sf, args.sfr)
     config = reader.get_config(args.config)
 
     # use dummy placement and schedule for running simulator without algorithm
@@ -66,6 +66,8 @@ def parse_args():
                         help="The duration of the simulation (simulates milliseconds).")
     parser.add_argument('-sf', '--sf', required=True, dest="sf",
                         help="VNF file which contains the SFCs and their respective SFs and their properties.")
+    parser.add_argument('-sfr', '--sfr', required=False, default='', dest='sfr',
+                        help="Path which contains the SF resource consumption functions.")
     parser.add_argument('-n', '--network', required=True, dest='network',
                         help="The GraphML network file that specifies the nodes and edges of the network.")
     parser.add_argument('-c', '--config', required=True, dest='config', help="Path to the simulator config file.")

--- a/src/coordsim/reader/reader.py
+++ b/src/coordsim/reader/reader.py
@@ -48,12 +48,12 @@ def load_resource_function(name, path):
         module = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(module)
     except Exception as ex:
-        raise Exception(f'Cannot load file {name}.py from specified location {path}.')
+        raise Exception(f'Cannot load file "{name}.py" from specified location "{path}".')
 
     try:
         return getattr(module, 'resource_function')
     except Exception as ex:
-        raise Exception(f'There is no resource_function defined in file {name}.py.')
+        raise Exception(f'There is no "resource_function" defined in file "{name}.py."')
 
 
 def get_sf(sf_file, resource_functions_path):
@@ -77,11 +77,11 @@ def get_sf(sf_file, resource_functions_path):
                                                                           default_processing_delay_stdev)
         if 'resource_function_id' in sf_list[sf_name]:
             try:
-                sf_list[sf_name]["resource_function"] = load_resource_function(sf_list[sf_name]['resource_function_id'],
+                sf_list[sf_name]['resource_function'] = load_resource_function(sf_list[sf_name]['resource_function_id'],
                                                                                resource_functions_path)
             except Exception as ex:
-                sf_list[sf_name]["resource_function_id"] = 'default'
-                sf_list[sf_name]["resource_function"] = default_resource_function
+                sf_list[sf_name]['resource_function_id'] = 'default'
+                sf_list[sf_name]['resource_function'] = default_resource_function
                 log.warning(f'{str(ex)} SF {sf_name} will use default resource function instead.')
         else:
             sf_list[sf_name]["resource_function_id"] = 'default'

--- a/src/coordsim/reader/reader.py
+++ b/src/coordsim/reader/reader.py
@@ -65,6 +65,7 @@ def get_sf(sf_file, resource_functions_path):
     # Configureable default mean and stdev defaults
     default_processing_delay_mean = 1.0
     default_processing_delay_stdev = 1.0
+    default_resource_function = lambda x: x
     sf_list = defaultdict(None)
     for sf_name, sf_details in sf_data['sf_list'].items():
         sf_list[sf_name] = sf_details
@@ -79,11 +80,12 @@ def get_sf(sf_file, resource_functions_path):
                                                                                resource_functions_path)
             except Exception as ex:
                 sf_list[sf_name]["resource_function_id"] = 'default'
-                sf_list[sf_name]["resource_function"] = lambda x: x
+                sf_list[sf_name]["resource_function"] = default_resource_function
                 log.warning(f'{repr(ex)} Default resource function will be used instead.')
         else:
             sf_list[sf_name]["resource_function_id"] = 'default'
-            sf_list[sf_name]["resource_function"] = lambda x: x
+            sf_list[sf_name]["resource_function"] = default_resource_function
+            log.warning(f'No resource function specified. Default resource function will be used instead.')
     return sf_list
 
 

--- a/src/coordsim/reader/reader.py
+++ b/src/coordsim/reader/reader.py
@@ -1,12 +1,13 @@
 import networkx as nx
 from geopy.distance import distance as dist
 import numpy as np
-import logging as log
+import logging
 import yaml
 import math
 from collections import defaultdict
 import importlib
 
+log = logging.getLogger(__name__)
 
 # Disclaimer: Some snippets of the following file were imported/modified from B-JointSP on GitHub.
 # Original code can be found on https://github.com/CN-UPB/B-JointSP
@@ -47,12 +48,12 @@ def load_resource_function(name, path):
         module = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(module)
     except Exception as ex:
-        raise Exception(f'Cannot load file {name}.py located at {path}.')
+        raise Exception(f'Cannot load file {name}.py from specified location {path}.')
 
     try:
         return getattr(module, 'resource_function')
     except Exception as ex:
-        raise Exception(f'There is no resource_function defined in file {name}.py')
+        raise Exception(f'There is no resource_function defined in file {name}.py.')
 
 
 def get_sf(sf_file, resource_functions_path):
@@ -81,11 +82,11 @@ def get_sf(sf_file, resource_functions_path):
             except Exception as ex:
                 sf_list[sf_name]["resource_function_id"] = 'default'
                 sf_list[sf_name]["resource_function"] = default_resource_function
-                log.warning(f'{repr(ex)} Default resource function will be used instead.')
+                log.warning(f'{str(ex)} SF {sf_name} will use default resource function instead.')
         else:
             sf_list[sf_name]["resource_function_id"] = 'default'
             sf_list[sf_name]["resource_function"] = default_resource_function
-            log.warning(f'No resource function specified. Default resource function will be used instead.')
+            log.info(f'No resource function specified for SF {sf_name}. Default resource function will be used instead.')
     return sf_list
 
 

--- a/src/coordsim/reader/reader.py
+++ b/src/coordsim/reader/reader.py
@@ -47,12 +47,12 @@ def load_resource_function(name, path):
         spec = importlib.util.spec_from_file_location(name, path + '/' + name + '.py')
         module = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(module)
-    except Exception as ex:
+    except Exception:
         raise Exception(f'Cannot load file "{name}.py" from specified location "{path}".')
 
     try:
         return getattr(module, 'resource_function')
-    except Exception as ex:
+    except Exception:
         raise Exception(f'There is no "resource_function" defined in file "{name}.py."')
 
 
@@ -66,7 +66,7 @@ def get_sf(sf_file, resource_functions_path):
     # Configureable default mean and stdev defaults
     default_processing_delay_mean = 1.0
     default_processing_delay_stdev = 1.0
-    default_resource_function = lambda x: x
+    def default_resource_function(x): return x
     sf_list = defaultdict(None)
     for sf_name, sf_details in sf_data['sf_list'].items():
         sf_list[sf_name] = sf_details
@@ -86,7 +86,8 @@ def get_sf(sf_file, resource_functions_path):
         else:
             sf_list[sf_name]["resource_function_id"] = 'default'
             sf_list[sf_name]["resource_function"] = default_resource_function
-            log.info(f'No resource function specified for SF {sf_name}. Default resource function will be used instead.')
+            log.info(
+                f'No resource function specified for SF {sf_name}. Default resource function will be used instead.')
     return sf_list
 
 

--- a/src/coordsim/simulation/flowsimulator.py
+++ b/src/coordsim/simulation/flowsimulator.py
@@ -190,7 +190,7 @@ class FlowSimulator:
 
             # Calculate the demanded capacity when the flow is processed at this node
             demanded_total_capacity = 0.0
-            for sf_i, sf_data in self.params.network.nodes[current_node_id]["available_sf"].items():
+            for sf_i, sf_data in self.params.network.nodes[current_node_id]['available_sf'].items():
                 if sf == sf_i:
                     # Include flows data rate in requested sf capacity calculation
                     demanded_total_capacity += self.params.sf_list[sf]['resource_function'](sf_data['load'] + flow.dr)
@@ -210,9 +210,9 @@ class FlowSimulator:
                                                   processing_delay))
 
                 # Add load to sf
-                self.params.network.nodes[current_node_id]["available_sf"][sf]['load'] += flow.dr
+                self.params.network.nodes[current_node_id]['available_sf'][sf]['load'] += flow.dr
                 # Set remaining node capacity
-                self.params.network.nodes[current_node_id]["remaining_cap"] = node_cap - demanded_total_capacity
+                self.params.network.nodes[current_node_id]['remaining_cap'] = node_cap - demanded_total_capacity
                 # Just for the sake of keeping lines small, the node_remaining_cap is updated again.
                 node_remaining_cap = self.params.network.nodes[current_node_id]["remaining_cap"]
 
@@ -238,13 +238,13 @@ class FlowSimulator:
                     metrics.remove_active_flow(flow, current_node_id, current_sf)
 
                 # Remove load from sf
-                self.params.network.nodes[current_node_id]["available_sf"][sf]['load'] -= flow.dr
+                self.params.network.nodes[current_node_id]['available_sf'][sf]['load'] -= flow.dr
                 # Recalculation is necessary because other flows could have already arrived or departed at the node
                 used_total_capacitiy = 0.0
-                for sf_i, sf_data in self.params.network.nodes[current_node_id]["available_sf"].items():
+                for sf_i, sf_data in self.params.network.nodes[current_node_id]['available_sf'].items():
                     used_total_capacitiy += self.params.sf_list[sf_i]['resource_function'](sf_data['load'])
                 # Set remaining node capacity
-                self.params.network.nodes[current_node_id]["remaining_cap"] = node_cap - used_total_capacitiy
+                self.params.network.nodes[current_node_id]['remaining_cap'] = node_cap - used_total_capacitiy
                 # Just for the sake of keeping lines small, the node_remaining_cap is updated again.
                 node_remaining_cap = self.params.network.nodes[current_node_id]["remaining_cap"]
 

--- a/src/coordsim/simulation/flowsimulator.py
+++ b/src/coordsim/simulation/flowsimulator.py
@@ -187,19 +187,32 @@ class FlowSimulator:
             # Add the delay to the flow's end2end delay
             metrics.add_processing_delay(processing_delay)
             flow.end2end_delay += processing_delay
+
+            # Calculate the demanded capacity when the flow is processed at this node
+            demanded_total_capacity = 0.0
+            for sf_i, sf_data in self.params.network.nodes[current_node_id]["available_sf"].items():
+                if sf == sf_i:
+                    # Include flows data rate in requested sf capacity calculation
+                    demanded_total_capacity += self.params.sf_list[sf]['resource_function'](sf_data['load'] + flow.dr)
+                else:
+                    demanded_total_capacity += self.params.sf_list[sf_i]['resource_function'](sf_data['load'])
+
             # Get node capacities
             node_cap = self.params.network.nodes[current_node_id]["cap"]
             node_remaining_cap = self.params.network.nodes[current_node_id]["remaining_cap"]
             assert node_remaining_cap >= 0, "Remaining node capacity cannot be less than 0 (zero)!"
             # Metrics: Add active flow to the SF once the flow has begun processing.
             metrics.add_active_flow(flow, current_node_id, current_sf)
-            if flow.dr <= node_remaining_cap:
+            if demanded_total_capacity <= node_cap:
                 log.info(
                     "Flow {} started proccessing at sf {} at node {}. Time: {}, "
                     "Processing delay: {}".format(flow.flow_id, current_sf, current_node_id, self.env.now,
                                                   processing_delay))
 
-                self.params.network.nodes[current_node_id]["remaining_cap"] -= flow.dr
+                # Add load to sf
+                self.params.network.nodes[current_node_id]["available_sf"][sf]['load'] += flow.dr
+                # Set remaining node capacity
+                self.params.network.nodes[current_node_id]["remaining_cap"] = node_cap - demanded_total_capacity
                 # Just for the sake of keeping lines small, the node_remaining_cap is updated again.
                 node_remaining_cap = self.params.network.nodes[current_node_id]["remaining_cap"]
 
@@ -223,7 +236,15 @@ class FlowSimulator:
                              .format(flow.flow_id, current_sf, current_node_id, self.env.now))
                     # Remove the active flow from the SF after it departed the SF
                     metrics.remove_active_flow(flow, current_node_id, current_sf)
-                self.params.network.nodes[current_node_id]["remaining_cap"] += flow.dr
+
+                # Remove load from sf
+                self.params.network.nodes[current_node_id]["available_sf"][sf]['load'] -= flow.dr
+                # Recalculation is necessary because other flows could have already arrived or departed at the node
+                used_total_capacitiy = 0.0
+                for sf_i, sf_data in self.params.network.nodes[current_node_id]["available_sf"].items():
+                    used_total_capacitiy += self.params.sf_list[sf_i]['resource_function'](sf_data['load'])
+                # Set remaining node capacity
+                self.params.network.nodes[current_node_id]["remaining_cap"] = node_cap - used_total_capacitiy
                 # Just for the sake of keeping lines small, the node_remaining_cap is updated again.
                 node_remaining_cap = self.params.network.nodes[current_node_id]["remaining_cap"]
 

--- a/src/coordsim/simulation/flowsimulator.py
+++ b/src/coordsim/simulation/flowsimulator.py
@@ -205,7 +205,7 @@ class FlowSimulator:
             metrics.add_active_flow(flow, current_node_id, current_sf)
             if demanded_total_capacity <= node_cap:
                 log.info(
-                    "Flow {} started proccessing at sf {} at node {}. Time: {}, "
+                    "Flow {} started processing at sf {} at node {}. Time: {}, "
                     "Processing delay: {}".format(flow.flow_id, current_sf, current_node_id, self.env.now,
                                                   processing_delay))
 
@@ -239,12 +239,14 @@ class FlowSimulator:
 
                 # Remove load from sf
                 self.params.network.nodes[current_node_id]['available_sf'][sf]['load'] -= flow.dr
+                assert self.params.network.nodes[current_node_id]['available_sf'][sf][
+                           'load'] >= 0, 'SF load cannot be less than 0!'
                 # Recalculation is necessary because other flows could have already arrived or departed at the node
-                used_total_capacitiy = 0.0
+                used_total_capacity = 0.0
                 for sf_i, sf_data in self.params.network.nodes[current_node_id]['available_sf'].items():
-                    used_total_capacitiy += self.params.sf_list[sf_i]['resource_function'](sf_data['load'])
+                    used_total_capacity += self.params.sf_list[sf_i]['resource_function'](sf_data['load'])
                 # Set remaining node capacity
-                self.params.network.nodes[current_node_id]['remaining_cap'] = node_cap - used_total_capacitiy
+                self.params.network.nodes[current_node_id]['remaining_cap'] = node_cap - used_total_capacity
                 # Just for the sake of keeping lines small, the node_remaining_cap is updated again.
                 node_remaining_cap = self.params.network.nodes[current_node_id]["remaining_cap"]
 

--- a/src/coordsim/simulation/simulatorparams.py
+++ b/src/coordsim/simulation/simulatorparams.py
@@ -26,6 +26,13 @@ class SimulatorParams:
         self.schedule = schedule
         # Placement of SFs in each node: defaultdict(list)
         self.sf_placement = sf_placement
+        # Update which sf is available at which node
+        for node_id, placed_sf_list in sf_placement.items():
+            available_sf = {}
+            for sf in placed_sf_list:
+                available_sf[sf] = self.network.nodes[node_id]['available_sf'].get(sf, {'load': 0.0})
+            self.network.nodes[node_id]['available_sf'] = available_sf
+
 
         # Flow interarrival exponential distribution mean: float
         self.inter_arr_mean = config['inter_arrival_mean']

--- a/src/coordsim/simulation/simulatorparams.py
+++ b/src/coordsim/simulation/simulatorparams.py
@@ -32,8 +32,6 @@ class SimulatorParams:
             for sf in placed_sf_list:
                 available_sf[sf] = self.network.nodes[node_id]['available_sf'].get(sf, {'load': 0.0})
             self.network.nodes[node_id]['available_sf'] = available_sf
-
-
         # Flow interarrival exponential distribution mean: float
         self.inter_arr_mean = config['inter_arrival_mean']
         # Flow data rate normal distribution mean: float

--- a/src/siminterface/simulator.py
+++ b/src/siminterface/simulator.py
@@ -21,7 +21,7 @@ class Simulator(SimulatorInterface):
         # Create CSV writer
         self.writer = ResultWriter(self.test_mode)
 
-    def init(self, network_file, service_functions_file, config_file, seed):
+    def init(self, network_file, service_functions_file, config_file, seed, resource_functions_path):
 
         # Initialize metrics, record start time
         metrics.reset()
@@ -31,7 +31,7 @@ class Simulator(SimulatorInterface):
         # Parse network and SFC + SF file
         self.network, self.ing_nodes = reader.read_network(network_file, node_cap=10, link_cap=10)
         self.sfc_list = reader.get_sfc(service_functions_file)
-        self.sf_list = reader.get_sf(service_functions_file)
+        self.sf_list = reader.get_sf(service_functions_file, resource_functions_path)
         self.config = reader.get_config(config_file)
 
         # Generate SimPy simulation environment

--- a/src/siminterface/simulator.py
+++ b/src/siminterface/simulator.py
@@ -78,6 +78,12 @@ class Simulator(SimulatorInterface):
         # Get the new placement from the action passed by the RL agent
         # Modify and set the placement parameter of the instantiated simulator object.
         self.simulator.params.sf_placement = actions.placement
+        # Update which sf is available at which node
+        for node_id, placed_sf_list in actions.placement.items():
+            available_sf = {}
+            for sf in placed_sf_list:
+                available_sf[sf] = self.simulator.params.network.nodes[node_id]['available_sf'].get(sf, {'load': 0.0})
+            self.simulator.params.network.nodes[node_id]['available_sf'] = available_sf
 
         # Get the new schedule from the SimulatorAction
         # Set it in the params of the instantiated simulator object.

--- a/src/siminterface/simulator.py
+++ b/src/siminterface/simulator.py
@@ -21,7 +21,7 @@ class Simulator(SimulatorInterface):
         # Create CSV writer
         self.writer = ResultWriter(self.test_mode)
 
-    def init(self, network_file, service_functions_file, config_file, seed, resource_functions_path):
+    def init(self, network_file, service_functions_file, config_file, seed, resource_functions_path=""):
 
         # Initialize metrics, record start time
         metrics.reset()

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -30,8 +30,8 @@ class TestFlowSimulator(TestCase):
         self.env = simpy.Environment()
         # Configure simulator parameters
         network, ing_nodes = reader.read_network(NETWORK_FILE, node_cap=10, link_cap=10)
-        sfc_list = reader.get_sfc(SERVICE_FUNCTIONS_FILE, RESOURCE_FUNCTION_PATH)
-        sf_list = reader.get_sf(SERVICE_FUNCTIONS_FILE)
+        sfc_list = reader.get_sfc(SERVICE_FUNCTIONS_FILE)
+        sf_list = reader.get_sf(SERVICE_FUNCTIONS_FILE, RESOURCE_FUNCTION_PATH)
         config = reader.get_config(CONFIG_FILE)
 
         sf_placement = dummy_data.triangle_placement

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -10,6 +10,7 @@ import logging
 
 NETWORK_FILE = "params/networks/triangle.graphml"
 SERVICE_FUNCTIONS_FILE = "params/services/abc.yaml"
+RESOURCE_FUNCTION_PATH = "params/services/resource_functions"
 CONFIG_FILE = "params/config/sim_config.yaml"
 SIMULATION_DURATION = 1000
 SEED = 1234
@@ -29,7 +30,7 @@ class TestFlowSimulator(TestCase):
         self.env = simpy.Environment()
         # Configure simulator parameters
         network, ing_nodes = reader.read_network(NETWORK_FILE, node_cap=10, link_cap=10)
-        sfc_list = reader.get_sfc(SERVICE_FUNCTIONS_FILE)
+        sfc_list = reader.get_sfc(SERVICE_FUNCTIONS_FILE, RESOURCE_FUNCTION_PATH)
         sf_list = reader.get_sf(SERVICE_FUNCTIONS_FILE)
         config = reader.get_config(CONFIG_FILE)
 

--- a/tests/test_simulatorInterface.py
+++ b/tests/test_simulatorInterface.py
@@ -8,6 +8,7 @@ from spinterface import SimulatorInterface, SimulatorAction, SimulatorState
 
 NETWORK_FILE = "params/networks/triangle.graphml"
 SERVICE_FUNCTIONS_FILE = "params/services/3sfcs.yaml"
+RESOURCE_FUNCTION_PATH = "params/services/resource_functions"
 CONFIG_FILE = "params/config/sim_config.yaml"
 
 SIMULATOR_MODULE_NAME = "siminterface.simulator"
@@ -27,7 +28,7 @@ class TestSimulatorInterface(TestCase):
         """
         # TODO: replace SimulatorInterface with implementation
         self.simulator = SIMULATOR_CLS(TEST_MODE)
-        self.simulator.init(NETWORK_FILE, SERVICE_FUNCTIONS_FILE, CONFIG_FILE, 1234)
+        self.simulator.init(NETWORK_FILE, SERVICE_FUNCTIONS_FILE, CONFIG_FILE, 1234, resource_functions_path=RESOURCE_FUNCTION_PATH)
 
     def test_apply(self):
         # test if placement and schedule can be applied
@@ -246,7 +247,7 @@ class TestSimulatorInterface(TestCase):
             }
         """
         network_stats = simulator_state.network_stats
-        self.assertIs(len(network_stats), 5)
+        self.assertIs(len(network_stats), 7)
         self.assertIn('total_flows', network_stats)
         self.assertIn('successful_flows', network_stats)
         self.assertIn('dropped_flows', network_stats)


### PR DESCRIPTION
VNF/SF can no specifiy a resource function which defines the needed capacity dependent on the individual SF load. If no resource function is specified, the default function `f(x)=x` will be used. When using resource functions a path parameter must be passed to the `simulator.init` function.

```yaml
 a:
    processing_delay_mean: 5.0
    processing_delay_stdev: 0.0
    resource_function_id: A
```

The `reader` when constructing the `sf_list` will try to load "A.py" in the specified path.
"A.py" has to contain a `resource_function(load)` function.

Note: do not include ".py" in the yaml resource_function_id field.
Note: resource functions are optional. Passing no path to the simulator will assign the default function to all SFs with warnings.
