### PR TITLE
Fixed key error when moving SF while flow is processed

### DIFF
--- a/src/coordsim/simulation/flowsimulator.py
+++ b/src/coordsim/simulation/flowsimulator.py
@@ -3,8 +3,8 @@ import random
 import numpy as np
 from coordsim.network.flow import Flow
 from coordsim.metrics import metrics
-log = logging.getLogger(__name__)
 
+log = logging.getLogger(__name__)
 
 """
 Flow Simulator class
@@ -238,15 +238,16 @@ class FlowSimulator:
                     metrics.remove_active_flow(flow, current_node_id, current_sf)
 
                 # Remove load from sf
-                if sf in self.params.network.nodes[current_node_id]['available_sf'][sf]:
+                if sf in self.params.network.nodes[current_node_id]['available_sf']:
                     self.params.network.nodes[current_node_id]['available_sf'][sf]['load'] -= flow.dr
+                    assert self.params.network.nodes[current_node_id]['available_sf'][sf]['load'] >= 0, \
+                        'SF load cannot be less than 0!'
                 else:
                     log.debug(f"SF {sf} was removed from {current_node_id}, while flow {flow.flow_id} was being "
                               f"processed. Still assume the flow could finish processing successfully.")
                     # TODO: drop the flow instead? or at least account for sf resources?
                     #  see https://github.com/RealVNF/coordination-simulation/pull/78#issuecomment-523921483
-                assert self.params.network.nodes[current_node_id]['available_sf'][sf]['load'] >= 0, \
-                    'SF load cannot be less than 0!'
+
                 # Recalculation is necessary because other flows could have already arrived or departed at the node
                 used_total_capacity = 0.0
                 for sf_i, sf_data in self.params.network.nodes[current_node_id]['available_sf'].items():

--- a/src/coordsim/simulation/flowsimulator.py
+++ b/src/coordsim/simulation/flowsimulator.py
@@ -238,9 +238,15 @@ class FlowSimulator:
                     metrics.remove_active_flow(flow, current_node_id, current_sf)
 
                 # Remove load from sf
-                self.params.network.nodes[current_node_id]['available_sf'][sf]['load'] -= flow.dr
-                assert self.params.network.nodes[current_node_id]['available_sf'][sf][
-                           'load'] >= 0, 'SF load cannot be less than 0!'
+                if sf in self.params.network.nodes[current_node_id]['available_sf'][sf]:
+                    self.params.network.nodes[current_node_id]['available_sf'][sf]['load'] -= flow.dr
+                else:
+                    log.debug(f"SF {sf} was removed from {current_node_id}, while flow {flow.flow_id} was being "
+                              f"processed. Still assume the flow could finish processing successfully.")
+                    # TODO: drop the flow instead? or at least account for sf resources?
+                    #  see https://github.com/RealVNF/coordination-simulation/pull/78#issuecomment-523921483
+                assert self.params.network.nodes[current_node_id]['available_sf'][sf]['load'] >= 0, \
+                    'SF load cannot be less than 0!'
                 # Recalculation is necessary because other flows could have already arrived or departed at the node
                 used_total_capacity = 0.0
                 for sf_i, sf_data in self.params.network.nodes[current_node_id]['available_sf'].items():


### PR DESCRIPTION
See https://github.com/RealVNF/coordination-simulation/pull/78#issuecomment-523914958

Current fix: Still allow flow to finish after VNF is moved. Ignore resource consumption for the (almost) removed SF.