### PR TITLE
Fix: graceful SF removal

### DIFF
--- a/src/siminterface/simulator.py
+++ b/src/siminterface/simulator.py
@@ -84,7 +84,7 @@ class Simulator(SimulatorInterface):
             # Keep only SFs which still process
             for sf, sf_data in self.simulator.params.network.nodes[node_id]['available_sf'].items():
                 if sf_data['load'] != 0:
-                    available[sf] = self.simulator.params.network.nodes[node_id]['available_sf'][sf]
+                    available[sf] = sf_data
             # Add all SFs which are in the placement
             for sf in placed_sf_list:
                 available[sf] = available.get(sf, {'load': 0.0})

--- a/src/siminterface/simulator.py
+++ b/src/siminterface/simulator.py
@@ -80,9 +80,15 @@ class Simulator(SimulatorInterface):
         self.simulator.params.sf_placement = actions.placement
         # Update which sf is available at which node
         for node_id, placed_sf_list in actions.placement.items():
+            available = {}
+            # Keep only SFs which still process
+            for sf, sf_data in self.simulator.params.network.nodes[node_id]['available_sf'].items():
+                if sf_data['load'] != 0:
+                    available[sf] = self.simulator.params.network.nodes[node_id]['available_sf'][sf]
+            # Add all SFs which are in the placement
             for sf in placed_sf_list:
-                self.simulator.params.network.nodes[node_id]['available_sf'][sf] = \
-                    self.simulator.params.network.nodes[node_id]['available_sf'].get(sf, {'load': 0.0})
+                available[sf] = available.get(sf, {'load': 0.0})
+            self.simulator.params.network.nodes[node_id]['available_sf'] = available
 
         # Get the new schedule from the SimulatorAction
         # Set it in the params of the instantiated simulator object.


### PR DESCRIPTION
This is an addition to #81. 

SFs with load 0 are not getting removed from the `available_sf` list when applying the new placement. This presents no problem as long as the SFs have no idle consumption.

With this fix, only SFs which are in the placement or still process flows are kept in the `available_sf` list.
When a SF is **not** in the placement but still processes a flow, it will be removed from the list as soon as it has completed all remaining processes.