### PR TITLE
separate config settings for deterministic arrival and size

### DIFF
--- a/params/config/sim_config.yaml
+++ b/params/config/sim_config.yaml
@@ -3,10 +3,13 @@
 # all parameters are required, defaults are in comments
 
 inter_arrival_mean: 10.0           # default: 10.0
+deterministic_arrival: True        # default: True
 flow_dr_mean: 1.0                  # default: 1.0
 flow_dr_stdev: 0.0                 # default: 0.0
-flow_size_shape: 0.001             # default: 0.001
+flow_size_shape: 0.001             # default: 0.001 (for deterministic!)
+deterministic_size: True           # default: True
 # if deterministic = True, the simulator reinterprets and uses inter_arrival_mean and flow_size_shape as fixed
 # deterministic values rather than means of a random distribution
-deterministic: True                # default: False
+# can be overridden by deterministic_arrival and deterministic_size
+#deterministic: True                # default: False
 run_duration: 100                  # default: 100

--- a/src/coordsim/reader/reader.py
+++ b/src/coordsim/reader/reader.py
@@ -63,7 +63,7 @@ def get_sf(sf_file, resource_functions_path):
     with open(sf_file) as yaml_stream:
         sf_data = yaml.load(yaml_stream, Loader=yaml.FullLoader)
 
-    # Configureable default mean and stdev defaults
+    # Configurable default mean and stddev defaults
     default_processing_delay_mean = 1.0
     default_processing_delay_stdev = 1.0
     def default_resource_function(x): return x
@@ -86,8 +86,7 @@ def get_sf(sf_file, resource_functions_path):
         else:
             sf_list[sf_name]["resource_function_id"] = 'default'
             sf_list[sf_name]["resource_function"] = default_resource_function
-            log.info(
-                f'No resource function specified for SF {sf_name}. Default resource function will be used instead.')
+            log.info(f'No resource function specified for SF {sf_name}. Default resource function will be used.')
     return sf_list
 
 

--- a/src/coordsim/simulation/flowsimulator.py
+++ b/src/coordsim/simulation/flowsimulator.py
@@ -46,18 +46,19 @@ class FlowSimulator:
             # set normally distributed flow data rate
             flow_dr = np.random.normal(self.params.flow_dr_mean, self.params.flow_dr_stdev)
 
-            # if "deterministic = True" use deterministic flow size and inter-arrival times (eg, for debugging)
-            if self.params.deterministic:
-                # Exponentially distributed random inter arrival rate using a user set (or default) mean
-                #
-                # use deterministic, fixed inter-arrival time for now
+            # set deterministic or random flow arrival times and flow sizes according to config
+            if self.params.deterministic_arrival:
                 inter_arr_time = self.params.inter_arr_mean
-                flow_size = self.params.flow_size_shape
-            # else use randomly distributed values (default)
             else:
-                inter_arr_time = random.expovariate(self.params.inter_arr_mean)
+                # Poisson arrival -> exponential distributed inter-arrival time
+                inter_arr_time = random.expovariate(lambd=1.0/self.params.inter_arr_mean)
+
+            if self.params.deterministic_size:
+                flow_size = self.params.flow_size_shape
+            else:
                 # heavy-tail flow size
                 flow_size = np.random.pareto(self.params.flow_size_shape) + 1
+
             # Skip flows with negative flow_dr or flow_size values
             if flow_dr <= 0.00 or flow_size <= 0.00:
                 continue

--- a/src/coordsim/simulation/simulatorparams.py
+++ b/src/coordsim/simulation/simulatorparams.py
@@ -41,7 +41,20 @@ class SimulatorParams:
         self.flow_size_shape = config['flow_size_shape']
         # if deterministic = True, the simulator reinterprets and uses inter_arrival_mean and flow_size_shape as fixed
         # deterministic values rather than means of a random distribution
-        self.deterministic = config['deterministic']
+        self.deterministic_arrival = None
+        self.deterministic_size = None
+        if 'deterministic' in config:
+            self.deterministic_arrival = config['deterministic']
+            self.deterministic_size = config['deterministic']
+        # deterministic_arrival/size override 'deterministic'
+        if 'deterministic_arrival' in config:
+            self.deterministic_arrival = config['deterministic_arrival']
+        if 'deterministic_size' in config:
+            self.deterministic_size = config['deterministic_size']
+        if self.deterministic_arrival is None or self.deterministic_size is None:
+            raise ValueError("'deterministic_arrival' or 'deterministic_size' are not set in simulator config.")
+
+        # also allow to set determinism for inter-arrival times and flow size separately
         # The duration of a run in the simulator's interface
         self.run_duration = config['run_duration']
 
@@ -50,7 +63,9 @@ class SimulatorParams:
         params_str = "Simulator parameters: \n"
         params_str += "seed: {}\n".format(self.seed)
         params_str += "inter_arr_mean: {}\n".format(self.inter_arr_mean)
+        params_str += f"deterministic_arrival: {self.deterministic_arrival}\n"
         params_str += "flow_dr_mean: {}\n".format(self.flow_dr_mean)
         params_str += "flow_dr_stdv: {}\n".format(self.flow_dr_stdev)
-        params_str += "flow_size_shape: {}".format(self.flow_size_shape)
+        params_str += "flow_size_shape: {}\n".format(self.flow_size_shape)
+        params_str += f"deterministic_size: {self.deterministic_size}\n"
         return params_str


### PR DESCRIPTION
We now also have `deterministic_arrival` and `deterministic_size` in the simulator config to set determinism separately here. Needed for scenario07 and 08.

Backward compatible, ie, if the fields are missing, the value of `deterministic` is used for both as before.
But in new scenarios, best practice is to specify them separately instead of using `deterministic`.