### PR TITLE
Fix: Return the requested taffic

### DIFF
--- a/src/coordsim/main.py
+++ b/src/coordsim/main.py
@@ -17,7 +17,7 @@ log = logging.getLogger(__name__)
 
 def main():
     args = parse_args()
-    metrics.reset()
+    metrics.reset_metrics()
     start_time = time.time()
     logging.basicConfig(level=logging.INFO)
 

--- a/src/coordsim/metrics/metrics.py
+++ b/src/coordsim/metrics/metrics.py
@@ -50,17 +50,17 @@ def reset_run_metrics():
     metrics['run_max_end2end_delay'] = 0.0
     metrics['run_processed_flows'] = 0
 
-    # total processed traffic (aggregated data rate) per node per SF within one run
-    metrics['run_total_processed_traffic'] = defaultdict(lambda: defaultdict(float))
+    # total requested traffic: increased whenever a flow is requesting processing before scheduling or processing
     metrics['run_total_requested_traffic'] = defaultdict(lambda: defaultdict(lambda: defaultdict(float)))
-
     # total generated traffic. traffic generate on ingress nodes is recorded
     #   this value could also be extracted from network and sim config file.
     metrics['run_total_requested_traffic_node'] = defaultdict(float)
+    # total processed traffic (aggregated data rate) per node per SF within one run
+    metrics['run_total_processed_traffic'] = defaultdict(lambda: defaultdict(float))
 
 
-def add_requesting_flow(flow, current_node_id, current_sf):
-    metrics['run_total_requested_traffic'][current_node_id][flow.sfc][current_sf] += flow.dr
+def add_requesting_flow(flow):
+    metrics['run_total_requested_traffic'][flow.current_node_id][flow.sfc][flow.current_sf] += flow.dr
 
 
 # call when new flows starts processing at an SF

--- a/src/coordsim/metrics/metrics.py
+++ b/src/coordsim/metrics/metrics.py
@@ -12,12 +12,12 @@ logger = logging.getLogger(__name__)
 metrics = {}
 
 
-# Initialize the metrics module
-def reset():
+def reset_metrics():
+    """Set/Reset all metrics"""
+
     # successful flows
     metrics['generated_flows'] = 0
     metrics['processed_flows'] = 0
-    metrics['run_processed_flows'] = 0
     metrics['dropped_flows'] = 0
     metrics['total_active_flows'] = 0
 
@@ -32,25 +32,31 @@ def reset():
 
     metrics['total_end2end_delay'] = 0.0
     metrics['avg_end2end_delay'] = 0.0
-    metrics['run_end2end_delay'] = 0.0
-    metrics['run_avg_end2end_delay'] = 0.0
-    metrics['run_max_end2end_delay'] = 0.0
-
     metrics['avg_total_delay'] = 0.0
 
     metrics['running_time'] = 0.0
 
     # Current number of active flows per each node
-    metrics['current_active_flows'] = defaultdict(lambda: defaultdict(lambda: defaultdict(np.int)))
-    metrics['current_traffic'] = defaultdict(lambda: defaultdict(lambda: defaultdict(np.float32)))
+    metrics['current_active_flows'] = defaultdict(lambda: defaultdict(lambda: defaultdict(int)))
+    metrics['current_traffic'] = defaultdict(lambda: defaultdict(lambda: defaultdict(float)))
+
+    reset_run_metrics()
+
+
+def reset_run_metrics():
+    """Set/Reset metrics belonging to one run"""
+    metrics['run_end2end_delay'] = 0
+    metrics['run_avg_end2end_delay'] = 0.0
+    metrics['run_max_end2end_delay'] = 0.0
+    metrics['run_processed_flows'] = 0
 
     # total processed traffic (aggregated data rate) per node per SF within one run
     metrics['run_total_processed_traffic'] = defaultdict(lambda: defaultdict(float))
-    metrics['run_total_requested_traffic'] = defaultdict(lambda: defaultdict(lambda: defaultdict(np.float32)))
+    metrics['run_total_requested_traffic'] = defaultdict(lambda: defaultdict(lambda: defaultdict(float)))
 
     # total generated traffic. traffic generate on ingress nodes is recorded
     #   this value could also be extracted from network and sim config file.
-    metrics['run_total_requested_traffic_node'] = defaultdict(np.float32)
+    metrics['run_total_requested_traffic_node'] = defaultdict(float)
 
 
 def add_requesting_flow(flow, current_node_id, current_sf):
@@ -166,12 +172,3 @@ def get_metrics():
     calc_avg_total_delay()
     calc_avg_end2end_delay()
     return metrics
-
-
-def reset_run():
-    metrics['run_end2end_delay'] = 0
-    metrics['run_processed_flows'] = 0
-    metrics['run_max_end2end_delay'] = 9999
-    metrics['run_total_processed_traffic'] = defaultdict(lambda: defaultdict(float))
-    metrics['run_total_requested_traffic'] = defaultdict(lambda: defaultdict(lambda: defaultdict(np.float32)))
-    metrics['run_total_requested_traffic_node'] = defaultdict(np.float32)

--- a/src/coordsim/simulation/flowsimulator.py
+++ b/src/coordsim/simulation/flowsimulator.py
@@ -112,7 +112,12 @@ class FlowSimulator:
         instead of pass_flow(). The position of the flow within the SFC is determined using current_position
         attribute of the flow object.
         """
+
+        # set current sf of flow
         sf = sfc[flow.current_position]
+        flow.current_sf = sf
+        metrics.add_requesting_flow(flow)
+
         next_node = self.get_next_node(flow, sf)
         yield self.env.process(self.forward_flow(flow, next_node))
 
@@ -182,8 +187,6 @@ class FlowSimulator:
 
         log.info("Flow {} STARTED PROCESSING at node {} for processing. Time: {}"
                  .format(flow.flow_id, flow.current_node_id, self.env.now))
-        # Metrics: Add flow request for sf at node regardless of whether it is processed or not.
-        metrics.add_requesting_flow(flow, current_node_id, sf)
 
         if sf in self.params.sf_placement[current_node_id]:
             current_sf = flow.current_sf

--- a/src/siminterface/simulator.py
+++ b/src/siminterface/simulator.py
@@ -26,7 +26,7 @@ class Simulator(SimulatorInterface):
     def init(self, network_file, service_functions_file, config_file, seed, trace=None, resource_functions_path=""):
 
         # Initialize metrics, record start time
-        metrics.reset()
+        metrics.reset_metrics()
         self.run_times = int(1)
         self.start_time = time.time()
 
@@ -102,7 +102,7 @@ class Simulator(SimulatorInterface):
         self.simulator.params.schedule = actions.scheduling
 
         # reset metrics for steps
-        metrics.reset_run()
+        metrics.reset_run_metrics()
 
         # Run the simulation again with the new params for the set duration.
         # Due to SimPy restraints, we multiply the duration by the run times because SimPy does not reset when run()

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -25,7 +25,7 @@ class TestFlowSimulator(TestCase):
         Setup test environment
         """
         logging.basicConfig(level=logging.ERROR)
-        metrics.reset()
+        metrics.reset_metrics()
 
         self.env = simpy.Environment()
         # Configure simulator parameters


### PR DESCRIPTION
Rather than the traffic at a VNF that should be processed, provide the traffic that's originally requested before applying the schedule and possibly sending it to another node.

Close #96 