### PR TITLE
Record max resource usage per run

### DIFF
--- a/src/coordsim/metrics/metrics.py
+++ b/src/coordsim/metrics/metrics.py
@@ -49,6 +49,7 @@ def reset_run_metrics():
     metrics['run_avg_end2end_delay'] = 0.0
     metrics['run_max_end2end_delay'] = 0.0
     metrics['run_processed_flows'] = 0
+    metrics['run_max_node_usage'] = defaultdict(float)
 
     # total requested traffic: increased whenever a flow is requesting processing before scheduling or processing
     metrics['run_total_requested_traffic'] = defaultdict(lambda: defaultdict(lambda: defaultdict(float)))
@@ -57,6 +58,14 @@ def reset_run_metrics():
     metrics['run_total_requested_traffic_node'] = defaultdict(float)
     # total processed traffic (aggregated data rate) per node per SF within one run
     metrics['run_total_processed_traffic'] = defaultdict(lambda: defaultdict(float))
+
+
+def calc_max_node_usage(node_id, current_usage):
+    """
+    Calculate the run's max node usage
+    """
+    if current_usage > metrics['run_max_node_usage'][node_id]:
+        metrics['run_max_node_usage'][node_id] = current_usage
 
 
 def add_requesting_flow(flow):

--- a/src/coordsim/simulation/flowsimulator.py
+++ b/src/coordsim/simulation/flowsimulator.py
@@ -222,6 +222,8 @@ class FlowSimulator:
                 self.params.network.nodes[current_node_id]['available_sf'][sf]['load'] += flow.dr
                 # Set remaining node capacity
                 self.params.network.nodes[current_node_id]['remaining_cap'] = node_cap - demanded_total_capacity
+                # Set max node usage
+                metrics.calc_max_node_usage(current_node_id, demanded_total_capacity)
                 # Just for the sake of keeping lines small, the node_remaining_cap is updated again.
                 node_remaining_cap = self.params.network.nodes[current_node_id]["remaining_cap"]
 

--- a/src/siminterface/simulator.py
+++ b/src/siminterface/simulator.py
@@ -139,11 +139,14 @@ class Simulator(SimulatorInterface):
         """
         Converts the NetworkX network in the simulator to a dict in a format specified in the SimulatorState class.
         """
+        max_node_usage_list = metrics.get_metrics()['run_max_node_usage']
         self.network_dict = {'nodes': [], 'edges': []}
         for node in self.params.network.nodes(data=True):
             node_cap = node[1]['cap']
-            used_node_cap = node[1]['cap'] - node[1]['remaining_cap']
-            self.network_dict['nodes'].append({'id': node[0], 'resource': node_cap, 'used_resources': used_node_cap})
+            run_max_node_usage = max_node_usage_list[node[0]]
+            # 'used_resources' here is the max usage for the run.
+            self.network_dict['nodes'].append({'id': node[0], 'resource': node_cap,
+                                               'used_resources': run_max_node_usage})
         for edge in self.network.edges(data=True):
             edge_src = edge[0]
             edge_dest = edge[1]


### PR DESCRIPTION
I've checked the solution using scenario09 from the RL agent, and the recorded usage is correct.

Close #77 