### PR TITLE
monitor dropped flows per node per run and pass as simulator state

### DIFF
--- a/src/coordsim/metrics/metrics.py
+++ b/src/coordsim/metrics/metrics.py
@@ -29,6 +29,8 @@ class Metrics:
         self.metrics['total_active_flows'] = 0
         # number of dropped flows per node and SF (locations)
         self.metrics['dropped_flows_locs'] = {v: {sf: 0 for sf in self.sfs.keys()} for v in self.network.nodes.keys()}
+        # number of dropped flow per node - reset every run
+        self.metrics['run_dropped_flows_per_node'] = {v: 0 for v in self.network.nodes.keys()}
 
         # delay
         self.metrics['total_processing_delay'] = 0.0
@@ -54,6 +56,8 @@ class Metrics:
 
     def reset_run_metrics(self):
         """Set/Reset metrics belonging to one run"""
+        self.metrics['run_dropped_flows_per_node'] = {v: 0 for v in self.network.nodes.keys()}
+
         self.metrics['run_end2end_delay'] = 0
         self.metrics['run_avg_end2end_delay'] = 0.0
         self.metrics['run_max_end2end_delay'] = 0.0
@@ -124,6 +128,7 @@ class Metrics:
         self.metrics['dropped_flows'] += 1
         self.metrics['total_active_flows'] -= 1
         self.metrics['dropped_flows_locs'][flow.current_node_id][flow.current_sf] += 1
+        self.metrics['run_dropped_flows_per_node'][flow.current_node_id] += 1
         assert self.metrics['total_active_flows'] >= 0, "Cannot have negative active flows"
 
     def add_processing_delay(self, delay):
@@ -152,9 +157,8 @@ class Metrics:
 
     def calc_avg_processing_delay(self):
         if self.metrics['num_processing_delays'] > 0:
-            self.metrics[
-                'avg_processing_delay'
-                ] = self.metrics['total_processing_delay'] / self.metrics['num_processing_delays']
+            self.metrics['avg_processing_delay'] \
+                = self.metrics['total_processing_delay'] / self.metrics['num_processing_delays']
         else:
             self.metrics['avg_processing_delay'] = 0
 

--- a/src/siminterface/simulator.py
+++ b/src/siminterface/simulator.py
@@ -202,7 +202,8 @@ class Simulator(SimulatorInterface):
             'run_avg_end2end_delay': stats['run_avg_end2end_delay'],
             'run_max_end2end_delay': stats['run_max_end2end_delay'],
             'run_avg_path_delay': stats['run_avg_path_delay'],
-            'run_total_processed_traffic': stats['run_total_processed_traffic']
+            'run_total_processed_traffic': stats['run_total_processed_traffic'],
+            'run_dropped_flows_per_node': stats['run_dropped_flows_per_node']
         }
 
     def get_active_ingress_nodes(self):

--- a/tests/test_simulatorInterface.py
+++ b/tests/test_simulatorInterface.py
@@ -249,7 +249,7 @@ class TestSimulatorInterface(TestCase):
             }
         """
         network_stats = simulator_state.network_stats
-        self.assertIs(len(network_stats), 10)
+        self.assertIs(len(network_stats), 11)
         self.assertIn('total_flows', network_stats)
         self.assertIn('successful_flows', network_stats)
         self.assertIn('dropped_flows', network_stats)


### PR DESCRIPTION
for https://github.com/RealVNF/rl-coordination/issues/173

currently not used afterall, but may be useful later